### PR TITLE
feat: Add Card to ACH and Gift Card Examples

### DIFF
--- a/examples/ach.html
+++ b/examples/ach.html
@@ -10,6 +10,13 @@
       const appId = '{APPLICATION_ID}';
       const locationId = '{LOCATION_ID}';
 
+      async function initializeCard(payments) {
+        const card = await payments.card();
+        await card.attach('#card-container');
+
+        return card;
+      }
+
       async function initializeACH(payments) {
         const ach = await payments.ach();
         // Note: ACH does not have an .attach(...) method
@@ -94,6 +101,15 @@
         }
 
         const payments = window.Square.payments(appId, locationId);
+
+        let card;
+        try {
+          card = await initializeCard(payments);
+        } catch (e) {
+          console.error('Initializing Card failed', e);
+          return;
+        }
+
         let ach;
         try {
           ach = await initializeACH(payments);
@@ -111,6 +127,7 @@
 
           try {
             // disable the submit button as we await tokenization and make a payment request.
+            cardButton.disabled = true;
             achButton.disabled = true;
             const token = await tokenize(paymentMethod, options);
             const paymentResults = await createPayment(token);
@@ -118,11 +135,17 @@
 
             console.debug('Payment Success', paymentResults);
           } catch (e) {
+            cardButton.disabled = false;
             achButton.disabled = false;
             displayPaymentResults('FAILURE');
             console.error(e.message);
           }
         }
+
+        const cardButton = document.getElementById('card-button');
+        cardButton.addEventListener('click', async function (event) {
+          await handlePaymentMethodSubmission(event, card);
+        });
 
         const achButton = document.getElementById('ach-button');
         achButton.addEventListener('click', async function (event) {
@@ -159,6 +182,9 @@
         />
       </fieldset>
       <button id="ach-button" type="button">Pay with Bank Account</button>
+
+      <div id="card-container"></div>
+      <button id="card-button" type="button">Pay $1.00</button>
     </form>
     <div id="payment-status-container"></div>
   </body>

--- a/examples/gift-card.html
+++ b/examples/gift-card.html
@@ -10,6 +10,13 @@
       const appId = '{APPLICATION_ID}';
       const locationId = '{LOCATION_ID}';
 
+      async function initializeCard(payments) {
+        const card = await payments.card();
+        await card.attach('#card-container');
+
+        return card;
+      }
+
       async function initializeGiftCard(payments) {
         const giftCard = await payments.giftCard();
         await giftCard.attach('#gift-card-container');
@@ -77,6 +84,14 @@
         }
 
         const payments = window.Square.payments(appId, locationId);
+
+        let card;
+        try {
+          card = await initializeCard(payments);
+        } catch (e) {
+          console.error('Initializing Gift Card failed', e);
+        }
+
         let giftCard;
         try {
           giftCard = await initializeGiftCard(payments);
@@ -90,6 +105,7 @@
 
           try {
             // disable the submit button as we await tokenization and make a payment request.
+            cardButton.disabled = true;
             giftCardButton.disabled = true;
             const token = await tokenize(paymentMethod);
             const paymentResults = await createPayment(token);
@@ -97,11 +113,17 @@
 
             console.debug('Payment Success', paymentResults);
           } catch (e) {
+            cardButton.disabled = false;
             giftCardButton.disabled = false;
             displayPaymentResults('FAILURE');
             console.error(e.message);
           }
         }
+
+        const cardButton = document.getElementById('card-button');
+        cardButton.addEventListener('click', async function (event) {
+          await handlePaymentMethodSubmission(event, card);
+        });
 
         const giftCardButton = document.getElementById('gift-card-button');
         giftCardButton.addEventListener('click', async function (event) {
@@ -114,6 +136,9 @@
     <form id="payment-form">
       <div id="gift-card-container"></div>
       <button id="gift-card-button" type="button">Pay with Gift Card</button>
+
+      <div id="card-container"></div>
+      <button id="card-button" type="button">Pay $1.00</button>
     </form>
     <div id="payment-status-container"></div>
   </body>

--- a/public/app.css
+++ b/public/app.css
@@ -22,7 +22,7 @@ body {
 }
 
 #card-container {
-  margin-top: 20px;
+  margin-top: 45px;
   /* this height depends on the size of the container element */
   /* We transition from a single row to double row at 485px */
   /* Settting this min-height minimizes the impact of the card form loading */
@@ -30,7 +30,7 @@ body {
 }
 
 #gift-card-container {
-  margin-top: 20px;
+  margin-top: 45px;
   min-height: 90px;
 }
 


### PR DESCRIPTION
Please explain the changes you made here.
This adds the card example back into ACH and Gift Cards to better assist with the written walkthrough.

![Screen Shot 2021-04-20 at 4 54 38 PM](https://user-images.githubusercontent.com/18686786/115477669-40bd2b80-a1f9-11eb-96f5-eb09f1a75776.png)
![Screen Shot 2021-04-20 at 4 54 54 PM](https://user-images.githubusercontent.com/18686786/115477670-41ee5880-a1f9-11eb-8425-ab6165b054bb.png)
![Screen Shot 2021-04-20 at 4 55 13 PM](https://user-images.githubusercontent.com/18686786/115477671-41ee5880-a1f9-11eb-9541-dc40608e2d45.png)
![Screen Shot 2021-04-20 at 4 55 25 PM](https://user-images.githubusercontent.com/18686786/115477672-4286ef00-a1f9-11eb-8c63-a2e97dc899c5.png)

_Does this close any currently open issues?_
No

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
