### PR TITLE
docs: Update README with links to API documentation and Longform walkthroughs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 Quickstart for using Square's Web Payments SDK
 
+- [Web Payments SDK Overview](https://developer.squareup.com/docs/web-payments/overview).
+- [API Documentation](https://developer.squareup.com/reference/sdks/web/payments).
+
 ## Getting Started
 
 Start by [cloning](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) this repository.


### PR DESCRIPTION
Please explain the changes you made here.
Adds links to our Longform walkthrough documentation and API docs in the README.

_Does this close any currently open issues?_
No

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
