### PR TITLE
Specify node version 16 as v18 has a breaking bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/square/web-payments-quickstart
 cd web-payments-quickstart
 ```
 
-Install [Node.js (>= v14)](https://nodejs.org/en/about/releases/) which will include `npm`. This repository contains an `.nvmrc` file if you use [`nvm`](https://github.com/nvm-sh/nvm) to manage your node versions.
+Install [Node.js (v16)](https://nodejs.org/en/about/releases/) which will include `npm`. This repository contains an `.nvmrc` file if you use [`nvm`](https://github.com/nvm-sh/nvm) to manage your node versions.
 
 Then, to install dependencies run:
 


### PR DESCRIPTION
Please explain the changes you made here.
We currently specify any node version from 14 and above but the current version of node (v18+) has a breaking bug.
V16 has been tested and works so this should be our specified version until v18's breaking bug is fixed

_Does this close any currently open issues?_
No
