### PR TITLE
Add verifyBuyer to google pay example

### DIFF
--- a/public/examples/google-pay-with-verification.html
+++ b/public/examples/google-pay-with-verification.html
@@ -36,10 +36,11 @@
         return googlePay;
       }
 
-      async function createPayment(token) {
+      async function createPayment(token, verificationToken) {
         const body = JSON.stringify({
           locationId,
           sourceId: token,
+          verificationToken,
         });
 
         const paymentResponse = await fetch('/payment', {
@@ -72,6 +73,30 @@
 
           throw new Error(errorMessage);
         }
+      }
+
+      async function verifyBuyer(payments, token) {
+        const verificationDetails = {
+          amount: '1.00',
+          billingContact: {
+            addressLines: ['123 Main Street', 'Apartment 1'],
+            familyName: 'Doe',
+            givenName: 'John',
+            email: 'jondoe@gmail.com',
+            country: 'GB',
+            phone: '3214563987',
+            region: 'LND',
+            city: 'London',
+          },
+          currencyCode: 'USD',
+          intent: 'CHARGE',
+        };
+
+        const verificationResults = await payments.verifyBuyer(
+          token,
+          verificationDetails
+        );
+        return verificationResults.token;
       }
 
       // status is either SUCCESS or FAILURE;
@@ -132,7 +157,11 @@
             // disable the submit button as we await tokenization and make a payment request.
             cardButton.disabled = true;
             const token = await tokenize(paymentMethod);
-            const paymentResults = await createPayment(token);
+            let verificationToken = await verifyBuyer(payments, token);
+            const paymentResults = await createPayment(
+              token,
+              verificationToken
+            );
             displayPaymentResults('SUCCESS');
 
             console.debug('Payment Success', paymentResults);

--- a/public/examples/google-pay.html
+++ b/public/examples/google-pay.html
@@ -36,10 +36,11 @@
         return googlePay;
       }
 
-      async function createPayment(token) {
+      async function createPayment(token, verificationToken) {
         const body = JSON.stringify({
           locationId,
           sourceId: token,
+          verificationToken,
         });
 
         const paymentResponse = await fetch('/payment', {
@@ -72,6 +73,30 @@
 
           throw new Error(errorMessage);
         }
+      }
+
+      async function verifyBuyer(payments, token) {
+        const verificationDetails = {
+          amount: '1.00',
+          billingContact: {
+            addressLines: ['123 Main Street', 'Apartment 1'],
+            familyName: 'Doe',
+            givenName: 'John',
+            email: 'jondoe@gmail.com',
+            country: 'GB',
+            phone: '3214563987',
+            region: 'LND',
+            city: 'London',
+          },
+          currencyCode: 'USD',
+          intent: 'CHARGE',
+        };
+
+        const verificationResults = await payments.verifyBuyer(
+          token,
+          verificationDetails
+        );
+        return verificationResults.token;
       }
 
       // status is either SUCCESS or FAILURE;
@@ -132,7 +157,11 @@
             // disable the submit button as we await tokenization and make a payment request.
             cardButton.disabled = true;
             const token = await tokenize(paymentMethod);
-            const paymentResults = await createPayment(token);
+            let verificationToken = await verifyBuyer(payments, token);
+            const paymentResults = await createPayment(
+              token,
+              verificationToken
+            );
             displayPaymentResults('SUCCESS');
 
             console.debug('Payment Success', paymentResults);

--- a/public/index.html
+++ b/public/index.html
@@ -63,6 +63,9 @@
             <a href="/examples/google-pay.html">Google Pay</a>
           </li>
           <li>
+            <a href="/examples/google-pay-with-verification.html">Google Pay with SCA</a>
+          </li>
+          <li>
             <a href="/examples/payment-request.html">Payment Request</a>
           </li>
           <li>


### PR DESCRIPTION
This PR amends the google pay example to include a call to verifyBuyer which per the public documentation ([link](https://developer.squareup.com/docs/web-payments/sca#step-1-add-strong-customer-authentication)) should be done for mandated SCA countries.

Changes to example list
<img width="1004" alt="Screenshot 2023-03-07 at 6 02 58 PM" src="https://user-images.githubusercontent.com/72568559/223573979-14cea750-c618-41db-bd23-7a2b165888fc.png">


Example successful payment
<img width="730" alt="Screenshot 2023-03-07 at 6 00 16 PM" src="https://user-images.githubusercontent.com/72568559/223573722-2053f545-375d-4f63-9499-fe5e574ae4c1.png">

