### PR TITLE
chore: ignore node-fetch 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore: '
+    ignore:
+      # remain on node-fetch 2.x as this repository is CJS, and 3.x is ESM-only
+      # https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md#converted-to-es-module
+      - dependency-name: 'node-fetch'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## What

- Updates dependabot to ignore node-fetch 3.x

## Why

node-fetch 3.x is infamously ESM-only which is problematic for CommonJS based
node applications. The main concern is the inability to `require` a CJS module -
instead forcing users to use dynamic imports to import the module.

That is an option; however, looking at node-fetch's upgrade guide their official
recommendation is to stay on v2 which is built with CommonJS. 

[upgrade guide](https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md#converted-to-es-module)


