### PR TITLE
chore: remove nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "dotenv": "^16.0.3",
         "micro": "^9.3.4",
         "microrouter": "^3.1.3",
-        "nanoid": "^3.3.4",
         "serve-handler": "^6.1.5",
         "square": "^25.2.0"
       },
@@ -7514,17 +7513,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -16727,11 +16715,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "dotenv": "^16.0.3",
     "micro": "^9.3.4",
     "microrouter": "^3.1.3",
-    "nanoid": "^3.3.4",
     "serve-handler": "^6.1.5",
     "square": "^25.2.0"
   },

--- a/server.js
+++ b/server.js
@@ -16,7 +16,8 @@ const {
 } = require('./server/schema');
 // square provides the API client and error types
 const { ApiError, client: square } = require('./server/square');
-const { nanoid } = require('nanoid');
+
+const crypto = require('crypto');
 
 async function createPayment(req, res) {
   const payload = await json(req);
@@ -26,11 +27,13 @@ async function createPayment(req, res) {
   if (!validatePaymentPayload(payload)) {
     throw createError(400, 'Bad Request');
   }
+
+  const idempotencyKey = payload.idempotencyKey || crypto.randomUUID();
+
   await retry(async (bail, attempt) => {
     try {
       logger.debug('Creating payment', { attempt });
 
-      const idempotencyKey = payload.idempotencyKey || nanoid();
       const payment = {
         idempotencyKey,
         locationId: payload.locationId,
@@ -95,11 +98,13 @@ async function storeCard(req, res) {
   if (!validateCreateCardPayload(payload)) {
     throw createError(400, 'Bad Request');
   }
+
+  const idempotencyKey = payload.idempotencyKey || crypto.randomUUID();
+
   await retry(async (bail, attempt) => {
     try {
       logger.debug('Storing card', { attempt });
 
-      const idempotencyKey = payload.idempotencyKey || nanoid();
       const cardReq = {
         idempotencyKey,
         sourceId: payload.sourceId,

--- a/server.js
+++ b/server.js
@@ -28,7 +28,10 @@ async function createPayment(req, res) {
     throw createError(400, 'Bad Request');
   }
 
-  const idempotencyKey = payload.idempotencyKey || crypto.randomUUID();
+  // An idempotencyKey prevents unintended results from accidental duplicate requests.
+  // For more information about Square's idempotency concept, please see
+  // https://developer.squareup.com/docs/build-basics/common-api-patterns/idempotency
+  const idempotencyKey = crypto.randomUUID();
 
   await retry(async (bail, attempt) => {
     try {
@@ -99,7 +102,10 @@ async function storeCard(req, res) {
     throw createError(400, 'Bad Request');
   }
 
-  const idempotencyKey = payload.idempotencyKey || crypto.randomUUID();
+  // An idempotencyKey prevents unintended results from accidental duplicate requests.
+  // For more information about Square's idempotency concept, please see
+  // https://developer.squareup.com/docs/build-basics/common-api-patterns/idempotency
+  const idempotencyKey = crypto.randomUUID();
 
   await retry(async (bail, attempt) => {
     try {

--- a/server/schema.js
+++ b/server/schema.js
@@ -10,7 +10,6 @@ const paymentSchema = {
   },
   optionalProperties: {
     amount: { type: 'uint32' },
-    idempotencyKey: { type: 'string' },
     customerId: { type: 'string' },
     verificationToken: { type: 'string' },
   },
@@ -23,7 +22,6 @@ const cardSchema = {
     customerId: { type: 'string' },
   },
   optionalProperties: {
-    idempotencyKey: { type: 'string' },
     verificationToken: { type: 'string' },
   },
 };


### PR DESCRIPTION
## What

- Removes `nanoid` from our dependencies
- Moves idempotencyKey setting outside the retry loop
- Removes `idempotencyKey` from the server's schema

## Why

- This is a quickstart example, meant to be as copy-pasteable as possible. Every
dependency introduces additional complexity that the user may not need / want.
Nanoid is now ESM only on version 4.x - rather than lock it to 3.x I think
removing the dependency (and any other superfluous dependencies) is the better
path forward.
- I noticed in passing that we are setting the idempotencyKey on every retry,
but considering when this code runs, setting an idempotencyKey _inside_ the
retry will cause a new key to be created on every retry. We should have a single
idempotencyKey set for the request across retries.
- Finally, PR review noticed that payload.idempotencyKey is outdated and not 
necessary anymore, so we removed it from the schema.