### PR TITLE
Type cast Version (and other 64-bit values in result.card object) to prevent auto-retries of storeCard

### DIFF
--- a/server.js
+++ b/server.js
@@ -114,12 +114,11 @@ async function storeCard(req, res) {
 
       logger.info('Store Card succeeded!', { result, statusCode });
 
-      // remove 64-bit values from card object.
-      // card is serialized by send method
-      // which will fail to serialize if response includes 64-bit value
-      delete result.card.expMonth;
-      delete result.card.expYear;
-      delete result.card.version;
+      // cast 64-bit values to string
+      // to prevent JSON serialization error during send method
+      result.card.expMonth = result.card.expMonth.toString();
+      result.card.expYear = result.card.expYear.toString();
+      result.card.version = result.card.version.toString();
 
       send(res, statusCode, {
         success: true,

--- a/server.js
+++ b/server.js
@@ -117,6 +117,7 @@ async function storeCard(req, res) {
       // remove 64-bit value from response
       delete result.card.expMonth;
       delete result.card.expYear;
+      delete result.card.version;
 
       send(res, statusCode, {
         success: true,

--- a/server.js
+++ b/server.js
@@ -114,7 +114,9 @@ async function storeCard(req, res) {
 
       logger.info('Store Card succeeded!', { result, statusCode });
 
-      // remove 64-bit value from response
+      // remove 64-bit values from card object.
+      // card is serialized by send method
+      // which will fail to serialize if response includes 64-bit value
       delete result.card.expMonth;
       delete result.card.expYear;
       delete result.card.version;


### PR DESCRIPTION
**Please explain the changes you made here:**
We've noticed that the store-card-on-file example has been visibly reporting failures. After some investigation, I realized that these failures were not caused by malformed requests, but by server.js auto-retrying (non-failing) requests.  These delinquent retries (correctly) failed with `source_used` errors. The retries were actually caused by an exception in this call to [send within storecCard](https://github.com/square/web-payments-quickstart/blob/042c73641a18f2b80a8d09d3cd09f5ad61871082/server.js#L121). One of the values in result.card (specifically _result.card.version_) is a 64-bit integer value, and "send" fails to encode this type. By casting this value (and other 64bit int values) to strings before we call "send", we can prevent the auto retries and no longer report failures. 

_Does this close any currently open issues?_

- [ ] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
