### PR TITLE
Removing .npmrc file so it doesn't override the registry setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.com/


### PR DESCRIPTION
Due to a change from InfoSec where the public NPM registry is blocked, it's causing `npm install` to fail since we have a `.npmrc` file that explicitly sets the registry.

This PR removes this `.npmrc` file so it uses the standard Block NPM regisry set in `~/.npmrc`.