### PR TITLE
Change Apple Pay HTML Element from Div to Button

### DIFF
--- a/public/examples/apple-pay.html
+++ b/public/examples/apple-pay.html
@@ -1,4 +1,4 @@
-<!doctype html>
+l<!doctype html>
 <html>
   <head>
     <link href="/app.css" rel="stylesheet" />
@@ -171,7 +171,7 @@
   </head>
   <body>
     <form id="payment-form">
-      <div id="apple-pay-button"></div>
+      <button id="apple-pay-button"></button>
       <div id="card-container"></div>
       <button id="card-button" type="button">Pay $1.00</button>
     </form>

--- a/public/examples/apple-pay.html
+++ b/public/examples/apple-pay.html
@@ -1,4 +1,4 @@
-l<!doctype html>
+<!doctype html>
 <html>
   <head>
     <link href="/app.css" rel="stylesheet" />
@@ -163,6 +163,7 @@ l<!doctype html>
         if (applePay) {
           const applePayButton = document.getElementById('apple-pay-button');
           applePayButton.addEventListener('click', async function (event) {
+            event.preventDefault();
             await handlePaymentMethodSubmission(event, applePay);
           });
         }


### PR DESCRIPTION
Please explain the changes you made here.
To ensure accessibility, this element should be a `button` instead of a `div`.  `button`s natively receive focus, while `div`s do not.

_Does this close any currently open issues?_

- [ ] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
